### PR TITLE
Add a docker-compose config that includes the backend template

### DIFF
--- a/docker-compose-dev-backend.yaml
+++ b/docker-compose-dev-backend.yaml
@@ -1,0 +1,36 @@
+version: '3'
+services:
+  apollo:
+    image: phanoix/micro_service_template:latest
+    environment: 
+      NODE_ENV: "production"
+      PRISMA_API_ENDPOINT: 'prisma'
+    ports:
+    - "4000:4000"
+    depends_on: 
+      - prisma
+  prisma:
+    image: prismagraphql/prisma:1.26
+    environment:
+      PRISMA_CONFIG: |
+        port: 4466
+        databases:
+          default:
+            connector: postgres
+            host: postgres
+            port: 5432
+            user: prisma
+            password: prisma
+            migrations: true
+    depends_on:
+      - postgres
+
+  postgres:
+    image: postgres:10.6
+    environment:
+      POSTGRES_USER: prisma
+      POSTGRES_PASSWORD: prisma
+    volumes:
+      - postgres:/var/lib/postgresql/data
+volumes:
+  postgres:


### PR DESCRIPTION
Pretty much identical to launching the backend separately, image should be replaced with back-end image(s) relevant to the service when using the template.